### PR TITLE
Feature: Accepts custom react components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneflowab/pomes",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A simple and powerful package to translate your react applications.",
   "main": "./dist/index.js",
   "typings": "./index.d.ts",

--- a/src/getTranslateFunction.js
+++ b/src/getTranslateFunction.js
@@ -6,11 +6,18 @@
 
 import React from 'react';
 
+const JSX_START = '{jsx-start}';
+const JSX_END = '{jsx-end}';
+
+const jsxStartRegExp = RegExp(JSX_START, 'gi');
+const jsxEndRegExp = RegExp(JSX_END, 'gi');
+const jsxRegExp = RegExp(`${JSX_START}|${JSX_END}`, 'gi');
+
 const getOccurrences = (rawText, regexp) => (rawText.match(regexp) || []).length;
 
 const throwIfTooManyJsxOccurrences = (rawText, allowedOccurrences = 1) => {
-  const startOccurrences = getOccurrences(rawText, /{jsx-start}/gi);
-  const endOccurrences = getOccurrences(rawText, /{jsx-end}/gi);
+  const startOccurrences = getOccurrences(rawText, jsxStartRegExp);
+  const endOccurrences = getOccurrences(rawText, jsxEndRegExp);
 
   if (startOccurrences !== endOccurrences) {
     throw new Error('Pomes error: The number of JSX start and end tags must be the same');
@@ -21,28 +28,26 @@ const throwIfTooManyJsxOccurrences = (rawText, allowedOccurrences = 1) => {
   }
 };
 
-const interpolateCustomComponents = (rawText, rawParams, component, componentProps = null) => {
-  const childText = /{jsx-start}(.+){jsx-end}/g.exec(rawText);
+const throwIfEndBeforeStart = (rawText) => {
+  const jsxMatches = rawText.match(jsxRegExp);
 
-  if (!childText) {
-    const text = rawText.replace('{jsx-start}', '').replace('{jsx-end}', '');
-
-    return [
-      text,
-      rawParams,
-    ];
+  if (jsxMatches && jsxMatches[0] === JSX_END) {
+    throw new Error('Pomes error: JSX start and end tags are in the wrong order');
   }
+};
 
-  const childPlaceholder = `{jsx-start}${childText[1]}{jsx-end}`;
+const interpolateCustomComponents = (rawText, rawParams, component, componentProps) => {
+  const childTexts = RegExp(`${JSX_START}(.+)${JSX_END}`, 'g').exec(rawText);
+  const [, childText] = childTexts || [undefined, ''];
+
+  const childPlaceholder = `${JSX_START}${childText}${JSX_END}`;
   const text = rawText.replace(childPlaceholder, '{customChild}');
-  let params;
 
-  if (rawParams) {
-    params = {
-      ...rawParams,
-      customChild: React.createElement(component, componentProps, interpolateParams(childText[1], rawParams)),
-    };
-  }
+  const params = {
+    ...rawParams,
+    // eslint-disable-next-line no-use-before-define
+    customChild: React.createElement(component, componentProps, interpolateParams(childText, rawParams)),
+  };
 
   return [text, params];
 };
@@ -52,14 +57,15 @@ const interpolateParams = (rawText, rawParams, component, componentProps) => {
   let params;
 
   if (component) {
-    throwIfTooManyJsxOccurrences(rawText, 1);
+    throwIfTooManyJsxOccurrences(rawText);
+    throwIfEndBeforeStart(rawText);
     [text, params] = interpolateCustomComponents(rawText, rawParams, component, componentProps);
   } else {
     throwIfTooManyJsxOccurrences(rawText, 0);
     [text, params] = [rawText, rawParams];
   }
 
-  if (!params) {
+  if (!params || !Object.keys(params).length) {
     return text;
   }
 
@@ -95,10 +101,11 @@ const getLangMessages = (translations, lang) => {
 };
 
 const getOptionValue = (options, key, defaultValue) => {
-  if (options === undefined) {
-    return defaultValue || null;
+  if (!options || !options[key]) {
+    return defaultValue;
   }
-  return options[key] === undefined ? (defaultValue || null) : options[key];
+
+  return options[key];
 };
 
 const getLangMessagesAndRules = (translations, lang, fallbackLang) => ({
@@ -133,7 +140,7 @@ export const legacyGetTranslateFunction = (translations, lang, fallbackLang) => 
     langMessages, fallbackLangMessages, pluralRule: plural_rule, pluralNumber: plural_number,
   } = getLangMessagesAndRules(translations, lang, fallbackLang);
 
-  return (textKey, params) => {
+  return (textKey, params = {}) => {
     // Checking if textkey contains a pluralize object.
     if (typeof textKey === 'object') {
       // eslint-disable-next-line no-param-reassign

--- a/src/message.jsx
+++ b/src/message.jsx
@@ -18,6 +18,7 @@ Message.propTypes = {
   pluralCondition: PropTypes.string,
   pluralId: PropTypes.string,
   values: PropTypes.shape(),
+  component: PropTypes.oneOfType([PropTypes.shape(), PropTypes.func]),
 };
 
 Message.defaultProps = {
@@ -27,6 +28,7 @@ Message.defaultProps = {
   pluralCondition: null,
   pluralId: null,
   values: {},
+  component: undefined,
 };
 
 export default Message;

--- a/test/__snapshots__/getTranslateFunction.spec.jsx.snap
+++ b/test/__snapshots__/getTranslateFunction.spec.jsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getTranslateFunction wraps the text with the custom component 1`] = `
+<span>
+  Olá 
+  <CustomComponent
+    className="CustomClassName"
+  >
+    Joe
+  </CustomComponent>
+  
+</span>
+`;

--- a/test/__snapshots__/getTranslateFunction.spec.jsx.snap
+++ b/test/__snapshots__/getTranslateFunction.spec.jsx.snap
@@ -1,6 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getTranslateFunction wraps the text with the custom component 1`] = `
+exports[`getTranslateFunction #default return the correct value when a jsx custom component with no children 1`] = `
+<span>
+  a text with no child text
+  <CustomComponent
+    className="CustomClassName"
+  >
+    
+  </CustomComponent>
+  in between
+</span>
+`;
+
+exports[`getTranslateFunction #default return the correct value when a string component but with no children 1`] = `
+<span>
+  no text 
+  <div
+    className="CustomClassName"
+  >
+    
+  </div>
+  in between
+</span>
+`;
+
+exports[`getTranslateFunction #default return the correct value when jsx-start end jsx-end are passed with children 1`] = `
+<span>
+  a text with
+  <CustomComponent
+    className="CustomClassName"
+  >
+     child text 
+  </CustomComponent>
+  in between
+</span>
+`;
+
+exports[`getTranslateFunction #default wrap the text with the custom component 1`] = `
 <span>
   Olá 
   <CustomComponent

--- a/test/__snapshots__/message.spec.js.snap
+++ b/test/__snapshots__/message.spec.js.snap
@@ -182,6 +182,80 @@ exports[`Message render 1`] = `
 </I18nProvider>
 `;
 
+exports[`Message with a custom component ignores custom component when no child text 1`] = `
+<I18nProvider
+  dispatch={null}
+  fallbackLang={null}
+  initialLang="en"
+  initialized={true}
+  lang="sv"
+  legacy={false}
+  translations={
+    Object {
+      "en": Object {
+        "before {jsx-start}middle{jsx-end} after": "before {jsx-start}middle{jsx-end} after",
+      },
+      "sv": Object {
+        "before {jsx-start}middle{jsx-end} after": "före {jsx-start}{jsx-end} efter",
+      },
+    }
+  }
+  useReducer={false}
+>
+  <Message
+    className="CustomClassName"
+    comment="Foo"
+    component={[Function]}
+    context={null}
+    foo="bar"
+    future={false}
+    id="before {jsx-start}middle{jsx-end} after"
+    pluralCondition={null}
+    pluralId={null}
+    values={Object {}}
+  >
+    före  efter
+  </Message>
+</I18nProvider>
+`;
+
+exports[`Message with a custom component ignores custom component when no jsx tags 1`] = `
+<I18nProvider
+  dispatch={null}
+  fallbackLang={null}
+  initialLang="en"
+  initialized={true}
+  lang="sv"
+  legacy={false}
+  translations={
+    Object {
+      "en": Object {
+        "before {jsx-start}middle{jsx-end} after": "before {jsx-start}middle{jsx-end} after",
+      },
+      "sv": Object {
+        "before {jsx-start}middle{jsx-end} after": "före efter",
+      },
+    }
+  }
+  useReducer={false}
+>
+  <Message
+    className="CustomClassName"
+    comment="Foo"
+    component={[Function]}
+    context={null}
+    foo="bar"
+    future={false}
+    id="before {jsx-start}middle{jsx-end} after"
+    pluralCondition={null}
+    pluralId={null}
+    values={Object {}}
+  >
+    före efter
+  </Message>
+</I18nProvider>
+`;
+
 exports[`Message with a custom component it accepts a custom component and variables 1`] = `
 <I18nProvider
   dispatch={null}

--- a/test/__snapshots__/message.spec.js.snap
+++ b/test/__snapshots__/message.spec.js.snap
@@ -182,43 +182,6 @@ exports[`Message render 1`] = `
 </I18nProvider>
 `;
 
-exports[`Message with a custom component ignores custom component when no child text 1`] = `
-<I18nProvider
-  dispatch={null}
-  fallbackLang={null}
-  initialLang="en"
-  initialized={true}
-  lang="sv"
-  legacy={false}
-  translations={
-    Object {
-      "en": Object {
-        "before {jsx-start}middle{jsx-end} after": "before {jsx-start}middle{jsx-end} after",
-      },
-      "sv": Object {
-        "before {jsx-start}middle{jsx-end} after": "före {jsx-start}{jsx-end} efter",
-      },
-    }
-  }
-  useReducer={false}
->
-  <Message
-    className="CustomClassName"
-    comment="Foo"
-    component={[Function]}
-    context={null}
-    foo="bar"
-    future={false}
-    id="before {jsx-start}middle{jsx-end} after"
-    pluralCondition={null}
-    pluralId={null}
-    values={Object {}}
-  >
-    före  efter
-  </Message>
-</I18nProvider>
-`;
-
 exports[`Message with a custom component ignores custom component when no jsx tags 1`] = `
 <I18nProvider
   dispatch={null}

--- a/test/__snapshots__/message.spec.js.snap
+++ b/test/__snapshots__/message.spec.js.snap
@@ -181,3 +181,157 @@ exports[`Message render 1`] = `
   </Message>
 </I18nProvider>
 `;
+
+exports[`Message with a custom component it accepts a custom component and variables 1`] = `
+<I18nProvider
+  dispatch={null}
+  fallbackLang={null}
+  initialLang="en"
+  initialized={true}
+  lang="pt"
+  legacy={false}
+  translations={
+    Object {
+      "en": Object {
+        "Hello {name} {jsx-start}Doe{jsx-end}": "Olá {name} {jsx-start}Doe{jsx-end}",
+      },
+      "pt": Object {
+        "Hello {name} {jsx-start}Doe{jsx-end}": "Olá {name} {jsx-start}Doe{jsx-end}",
+      },
+    }
+  }
+  useReducer={false}
+>
+  <Message
+    className="CustomClassName"
+    comment="Foo"
+    component={[Function]}
+    context={null}
+    foo="bar"
+    future={false}
+    id="Hello {name} {jsx-start}Doe{jsx-end}"
+    pluralCondition={null}
+    pluralId={null}
+    values={
+      Object {
+        "name": "John",
+      }
+    }
+  >
+    <span>
+      Olá 
+      John
+       
+      <CustomComponent
+        className="CustomClassName"
+        context={null}
+        foo="bar"
+      >
+        <div>
+          Doe
+        </div>
+      </CustomComponent>
+    </span>
+  </Message>
+</I18nProvider>
+`;
+
+exports[`Message with a custom component it accepts a custom component and wrapped variables 1`] = `
+<I18nProvider
+  dispatch={null}
+  fallbackLang={null}
+  initialLang="en"
+  initialized={true}
+  lang="pt"
+  legacy={false}
+  translations={
+    Object {
+      "en": Object {
+        "Hello {jsx-start}{name}{jsx-end}": "Olá {jsx-start}{name}{jsx-end}",
+      },
+      "pt": Object {
+        "Hello {jsx-start}{name}{jsx-end}": "Olá {jsx-start}{name}{jsx-end}",
+      },
+    }
+  }
+  useReducer={false}
+>
+  <Message
+    className="CustomClassName"
+    comment="Foo"
+    component={[Function]}
+    context={null}
+    foo="bar"
+    future={false}
+    id="Hello {jsx-start}{name}{jsx-end}"
+    pluralCondition={null}
+    pluralId={null}
+    values={
+      Object {
+        "name": "Joe",
+      }
+    }
+  >
+    <span>
+      Olá 
+      <CustomComponent
+        className="CustomClassName"
+        context={null}
+        foo="bar"
+      >
+        <div>
+          Joe
+        </div>
+      </CustomComponent>
+    </span>
+  </Message>
+</I18nProvider>
+`;
+
+exports[`Message with a custom component wraps the text with the custom component 1`] = `
+<I18nProvider
+  dispatch={null}
+  fallbackLang={null}
+  initialLang="en"
+  initialized={true}
+  lang="pt"
+  legacy={false}
+  translations={
+    Object {
+      "en": Object {
+        "Hello {jsx-start}Joe{jsx-end}": "Olá {jsx-start}Joe{jsx-end}",
+      },
+      "pt": Object {
+        "Hello {jsx-start}Joe{jsx-end}": "Olá {jsx-start}Joe{jsx-end}",
+      },
+    }
+  }
+  useReducer={false}
+>
+  <Message
+    className="CustomClassName"
+    comment="Foo"
+    component={[Function]}
+    context={null}
+    foo="bar"
+    future={false}
+    id="Hello {jsx-start}Joe{jsx-end}"
+    pluralCondition={null}
+    pluralId={null}
+    values={Object {}}
+  >
+    <span>
+      Olá 
+      <CustomComponent
+        className="CustomClassName"
+        context={null}
+        foo="bar"
+      >
+        <div>
+          Joe
+        </div>
+      </CustomComponent>
+    </span>
+  </Message>
+</I18nProvider>
+`;

--- a/test/getTranslateFunction.spec.jsx
+++ b/test/getTranslateFunction.spec.jsx
@@ -1,97 +1,389 @@
 import React from 'react';
-import getTranslateFunction from 'getTranslateFunction';
+import getTranslateFunction, { legacyGetTranslateFunction } from 'getTranslateFunction';
 
 describe('getTranslateFunction', () => {
-  it('wraps the text with the custom component', () => {
-    const template = 'Hello {jsx-start}Joe{jsx-end}';
-    const translations = {
-      sv: { [template]: 'Olá {jsx-start}Joe{jsx-end}' },
-      en: { [template]: template },
-    };
-    const CustomComponent = ({ children }) => <div>{children}</div>;
-    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+  describe('#default', () => {
+    it('wrap the text with the custom component', () => {
+      const template = 'Hello {jsx-start}Joe{jsx-end}';
+      const translations = {
+        sv: { [template]: 'Olá {jsx-start}Joe{jsx-end}' },
+        en: { [template]: template },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
 
-    const parameters = {
-      id: template,
-      comment: 'Foo',
-      component: CustomComponent,
-      className: 'CustomClassName',
-    };
-    expect(translateFunction(parameters)).toMatchSnapshot();
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toMatchSnapshot();
+    });
+
+    it('throw when not having both start and end jsx tags', () => {
+      const template = 'something {jsx-start}something else';
+      const translations = {
+        sv: { [template]: 'text {jsx-start}mer text' },
+        en: { [template]: template },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(() => translateFunction(parameters)).toThrow('Pomes error: The number of JSX start and end tags must be the same');
+    });
+
+    it('throw when jsx-start and jsx-end are missplaced', () => {
+      const template = 'something {jsx-end}something else{jsx-start}';
+      const translations = {
+        sv: { [template]: 'text {jsx-end}mer text{jsx-start}' },
+        en: { [template]: template },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(() => translateFunction(parameters)).toThrow('Pomes error: JSX start and end tags are in the wrong order');
+    });
+
+    it('throw when multiple custom component levels', () => {
+      const template = 'foo {jsx-start}some {jsx-start}bar{jsx-end} thing{jsx-end} baz';
+      const translations = {
+        sv: { [template]: 'före {jsx-start}mitten-start {jsx-start}inuti{jsx-end} mitten-slut{jsx-end} efter' },
+        en: { [template]: template },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+    });
+
+    it('throw when multiple occurences of custom component', () => {
+      const template = 'start {jsx-start}middle-1{jsx-end} between {jsx-start}middle-2{jsx-end} end';
+      const translations = {
+        sv: {
+          [template]: 'före {jsx-start}nummer-1{jsx-end} mitten {jsx-start}nummer-2{jsx-end} efter',
+        },
+        en: {
+          [template]: template,
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+    });
+
+    it('throw when jsx tags without custom component', () => {
+      const template = 'something {jsx-start}child text{jsx-end}';
+      const translations = {
+        sv: { [template]: 'text {jsx-start}mer text{jsx-end}' },
+        en: { [template]: template },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: undefined,
+        className: 'CustomClassName',
+      };
+      expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+    });
+
+    it('return the correct value when jsx-start end jsx-end are passed with children', () => {
+      const template = 'some{jsx-start} child text {jsx-end}in between';
+      const translations = {
+        sv: { [template]: 'a text with{jsx-start} child text {jsx-end}in between' },
+        en: { [template]: template },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const CustomComponent = ({ children }) => (
+        <p>
+        a Custom Component to be used in a translated message:
+          {children}
+        </p>
+      );
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toMatchSnapshot();
+    });
+
+    it('return the correct value when a jsx custom component with no children', () => {
+      const template = 'no text{jsx-start}{jsx-end}in between';
+      const translations = {
+        sv: { [template]: 'a text with no child text{jsx-start}{jsx-end}in between' },
+        en: { [template]: template },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const CustomComponent = ({ children }) => (
+        <p>
+        a Custom Component to be used in a translated message:
+          {children}
+        </p>
+      );
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: CustomComponent,
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toMatchSnapshot();
+    });
+
+    it('return the correct value when a string component but with no children', () => {
+      const template = 'nothing {jsx-start}{jsx-end}in between';
+      const translations = {
+        sv: { [template]: 'no text {jsx-start}{jsx-end}in between' },
+        en: { [template]: template },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: 'div',
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toMatchSnapshot();
+    });
+
+    it('translate with options and the the parent language splitted by dash', () => {
+      const template = 'nothing in between';
+      const svTemplate = 'no text in between';
+      const translations = {
+        sv: { [template]: svTemplate },
+        en: { [template]: template },
+        options: {
+          plural_rule: 'n != 1',
+          plural_number: 2,
+        },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv-US', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: 'div',
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toEqual(svTemplate);
+    });
+
+    it('translate with empty options object', () => {
+      const template = 'nothing in between';
+      const svTemplate = 'no text in between';
+      const translations = {
+        sv: { [template]: svTemplate },
+        en: { [template]: template },
+        options: { },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+      };
+      expect(translateFunction(parameters)).toEqual(svTemplate);
+    });
+
+    it('translate based on the the fall back lang', () => {
+      const template = 'the fall back translation of a message';
+      const translations = {
+        en: { [template]: template },
+      };
+      const translateFunction = getTranslateFunction(translations, 'ar', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        component: 'div',
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toEqual(template);
+    });
+
+    it('return the message id when language and fallback language are not translated', () => {
+      const translations = {};
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: 'the message id',
+        comment: 'Foo',
+        component: 'div',
+        className: 'CustomClassName',
+      };
+      expect(translateFunction(parameters)).toEqual(parameters.id);
+    });
+
+    it('return the message id when the fallback language is not translated', () => {
+      const translations = {
+        sv: { 'a sv message': 'the translated sv message' },
+        en: { 'a en message': 'the translated en message' },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv');
+
+      const parameters = {
+        id: 'the message id',
+        comment: 'Foo',
+      };
+      expect(translateFunction(parameters)).toEqual(parameters.id);
+    });
+
+    it('return the message id when the fallback language is not translated', () => {
+      const translations = {
+        sv: { 'a sv message': 'the translated sv message' },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: 'the message id',
+        comment: 'Foo',
+      };
+      expect(translateFunction(parameters)).toEqual(parameters.id);
+    });
+
+    it('return the message id when the message is not translated in any languages', () => {
+      const translations = {
+        sv: { 'a sv message': 'the translated sv message' },
+        en: { 'an en message': 'the translated en message' },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: 'the message id',
+        comment: 'Foo',
+        values: {
+          value: null,
+        },
+      };
+      expect(translateFunction(parameters)).toEqual(parameters.id);
+    });
+
+    it('coerce the passed value to string when the passed value is falsey', () => {
+      const translateFunction = getTranslateFunction({}, 'sv', 'en');
+
+      const parameters = {
+        id: 'the message id: {value}',
+        comment: 'Foo',
+        values: {
+          value: null,
+        },
+      };
+      expect(translateFunction(parameters)).toEqual('the message id: null');
+    });
+
+    it('return the plural translation of a message', () => {
+      const translations = {
+        sv: { 'a sv message': 'the translated sv message' },
+        en: { 'an en message': 'the translated en message' },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: 'the message id',
+        pluralId: 'the plural id',
+        pluralCondition: 'count',
+        comment: 'Foo',
+        values: {
+          count: 2,
+        },
+      };
+      expect(translateFunction(parameters)).toEqual(parameters.pluralId);
+    });
+
+    it('return the message id without translating it when it is a future message', () => {
+      const template = 'the message';
+      const translations = {
+        sv: { [template]: 'the message in sv' },
+        en: { [template]: 'the message in en' },
+      };
+      const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+      const parameters = {
+        id: template,
+        comment: 'Foo',
+        future: true,
+      };
+      expect(translateFunction(parameters)).toEqual(template);
+    });
   });
 
-  it('throws when not having both start and end jsx tags', () => {
-    const template = 'something {jsx-start}something else';
-    const translations = {
-      sv: { [template]: 'text {jsx-start}mer text' },
-      en: { [template]: template },
-    };
-    const CustomComponent = ({ children }) => <div>{children}</div>;
-    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+  describe('#legacyGetTranslateFunction', () => {
+    it('return a singular message without params', () => {
+      const template = 'a singular message';
+      const translations = {
+        sv: { [template]: 'a singular message in sv' },
+        en: { [template]: 'a singular message in en' },
+      };
+      const translateFunction = legacyGetTranslateFunction(translations, 'sv', 'en');
 
-    const parameters = {
-      id: template,
-      comment: 'Foo',
-      component: CustomComponent,
-      className: 'CustomClassName',
-    };
-    expect(() => translateFunction(parameters)).toThrow('Pomes error: The number of JSX start and end tags must be the same');
-  });
+      expect(translateFunction(template)).toEqual('a singular message in sv');
+    });
 
-  it('throws when multiple custom component levels', () => {
-    const template = 'foo {jsx-start}some {jsx-start}bar{jsx-end} thing{jsx-end} baz';
-    const translations = {
-      sv: { [template]: 'före {jsx-start}mitten-start {jsx-start}inuti{jsx-end} mitten-slut{jsx-end} efter' },
-      en: { [template]: template },
-    };
-    const CustomComponent = ({ children }) => <div>{children}</div>;
-    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+    it('return a singular message with params', () => {
+      const template = 'this message has {count} translations';
+      const translations = {
+        sv: { [template]: 'this sv message has {count} translations' },
+        en: { [template]: 'this en message has {count} translations' },
+      };
+      const translateFunction = legacyGetTranslateFunction(translations, 'sv', 'en');
 
-    const parameters = {
-      id: template,
-      comment: 'Foo',
-      component: CustomComponent,
-      className: 'CustomClassName',
-    };
-    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
-  });
+      const params = { count: 2 };
+      expect(translateFunction(template, params)).toEqual('this sv message has 2 translations');
+    });
 
-  it('throws when multiple occurences of custom component', () => {
-    const template = 'start {jsx-start}middle-1{jsx-end} between {jsx-start}middle-2{jsx-end} end';
-    const translations = {
-      sv: {
-        [template]: 'före {jsx-start}nummer-1{jsx-end} mitten {jsx-start}nummer-2{jsx-end} efter',
-      },
-      en: {
-        [template]: template,
-      },
-    };
-    const CustomComponent = ({ children }) => <div>{children}</div>;
-    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+    it('return a plural message', () => {
+      const template = [
+        'the singular form',
+        'the plural form: regarding to {count} items',
+        'count',
+      ];
+      const translations = {
+        sv: {
+          [template[0]]: 'the singular form in sv',
+          [template[1]]: 'the plural form in sv: regarding to {count} items',
+        },
+        en: {
+          [template[0]]: 'the singular form in en',
+          [template[1]]: 'the plural form in en: regarding to {count} items',
+        },
+      };
+      const translateFunction = legacyGetTranslateFunction(translations, 'sv', 'en');
 
-    const parameters = {
-      id: template,
-      comment: 'Foo',
-      component: CustomComponent,
-      className: 'CustomClassName',
-    };
-    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
-  });
-
-  it('throws when jsx tags without custom component', () => {
-    const template = 'something {jsx-start}child text{jsx-end}';
-    const translations = {
-      sv: { [template]: 'text {jsx-start}mer text{jsx-end}' },
-      en: { [template]: template },
-    };
-    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
-
-    const parameters = {
-      id: template,
-      comment: 'Foo',
-      component: undefined,
-      className: 'CustomClassName',
-    };
-    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+      const params = { count: 2 };
+      expect(translateFunction(template, params)).toEqual('the plural form in sv: regarding to 2 items');
+    });
   });
 });

--- a/test/getTranslateFunction.spec.jsx
+++ b/test/getTranslateFunction.spec.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import getTranslateFunction from 'getTranslateFunction';
+
+describe('getTranslateFunction', () => {
+  it('wraps the text with the custom component', () => {
+    const template = 'Hello {jsx-start}Joe{jsx-end}';
+    const translations = {
+      sv: { [template]: 'Olá {jsx-start}Joe{jsx-end}' },
+      en: { [template]: template },
+    };
+    const CustomComponent = ({ children }) => <div>{children}</div>;
+    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+    const parameters = {
+      id: template,
+      comment: 'Foo',
+      component: CustomComponent,
+      className: 'CustomClassName',
+    };
+    expect(translateFunction(parameters)).toMatchSnapshot();
+  });
+
+  it('throws when not having both start and end jsx tags', () => {
+    const template = 'something {jsx-start}something else';
+    const translations = {
+      sv: { [template]: 'text {jsx-start}mer text' },
+      en: { [template]: template },
+    };
+    const CustomComponent = ({ children }) => <div>{children}</div>;
+    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+    const parameters = {
+      id: template,
+      comment: 'Foo',
+      component: CustomComponent,
+      className: 'CustomClassName',
+    };
+    expect(() => translateFunction(parameters)).toThrow('Pomes error: The number of JSX start and end tags must be the same');
+  });
+
+  it('throws when multiple custom component levels', () => {
+    const template = 'foo {jsx-start}some {jsx-start}bar{jsx-end} thing{jsx-end} baz';
+    const translations = {
+      sv: { [template]: 'före {jsx-start}mitten-start {jsx-start}inuti{jsx-end} mitten-slut{jsx-end} efter' },
+      en: { [template]: template },
+    };
+    const CustomComponent = ({ children }) => <div>{children}</div>;
+    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+    const parameters = {
+      id: template,
+      comment: 'Foo',
+      component: CustomComponent,
+      className: 'CustomClassName',
+    };
+    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+  });
+
+  it('throws when multiple occurences of custom component', () => {
+    const template = 'start {jsx-start}middle-1{jsx-end} between {jsx-start}middle-2{jsx-end} end';
+    const translations = {
+      sv: {
+        [template]: 'före {jsx-start}nummer-1{jsx-end} mitten {jsx-start}nummer-2{jsx-end} efter',
+      },
+      en: {
+        [template]: template,
+      },
+    };
+    const CustomComponent = ({ children }) => <div>{children}</div>;
+    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+    const parameters = {
+      id: template,
+      comment: 'Foo',
+      component: CustomComponent,
+      className: 'CustomClassName',
+    };
+    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+  });
+
+  it('throws when jsx tags without custom component', () => {
+    const template = 'something {jsx-start}child text{jsx-end}';
+    const translations = {
+      sv: { [template]: 'text {jsx-start}mer text{jsx-end}' },
+      en: { [template]: template },
+    };
+    const translateFunction = getTranslateFunction(translations, 'sv', 'en');
+
+    const parameters = {
+      id: template,
+      comment: 'Foo',
+      component: undefined,
+      className: 'CustomClassName',
+    };
+    expect(() => translateFunction(parameters)).toThrow('Pomes error: Only one JSX tag pair is allowed');
+  });
+});

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -20,10 +20,10 @@ describe('Message', () => {
     it('skip translation of future singular messages', () => {
       const translations = {
         pt: {
-          'Hello': 'Olá',
+          Hello: 'Olá',
         },
         en: {
-          'Hello': 'Hello',
+          Hello: 'Hello',
         },
       };
       const message = mount(
@@ -174,33 +174,6 @@ describe('Message', () => {
       );
 
       expect(message.text()).toEqual('före efter');
-      expect(toJson(message)).toMatchSnapshot();
-    });
-
-    it('ignores custom component when no child text', () => {
-      const template = 'before {jsx-start}middle{jsx-end} after';
-      const translations = {
-        sv: {
-          [template]: 'före {jsx-start}{jsx-end} efter',
-        },
-        en: {
-          [template]: template,
-        },
-      };
-      const CustomComponent = ({ children }) => <div>{children}</div>;
-      const message = mount(
-        <I18nProvider translations={translations} lang="sv" initialLang="en" initialized>
-          <Message
-            id={template}
-            comment="Foo"
-            component={CustomComponent}
-            className="CustomClassName"
-            foo="bar"
-          />
-        </I18nProvider>,
-      );
-
-      expect(message.text()).toEqual('före  efter');
       expect(toJson(message)).toMatchSnapshot();
     });
   });

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -149,12 +149,66 @@ describe('Message', () => {
       expect(message.text()).toEqual('Olá John Doe');
       expect(toJson(message)).toMatchSnapshot();
     });
+
+    it('ignores custom component when no jsx tags', () => {
+      const template = 'before {jsx-start}middle{jsx-end} after';
+      const translations = {
+        sv: {
+          [template]: 'före efter',
+        },
+        en: {
+          [template]: template,
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const message = mount(
+        <I18nProvider translations={translations} lang="sv" initialLang="en" initialized>
+          <Message
+            id={template}
+            comment="Foo"
+            component={CustomComponent}
+            className="CustomClassName"
+            foo="bar"
+          />
+        </I18nProvider>,
+      );
+
+      expect(message.text()).toEqual('före efter');
+      expect(toJson(message)).toMatchSnapshot();
+    });
+
+    it('ignores custom component when no child text', () => {
+      const template = 'before {jsx-start}middle{jsx-end} after';
+      const translations = {
+        sv: {
+          [template]: 'före {jsx-start}{jsx-end} efter',
+        },
+        en: {
+          [template]: template,
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const message = mount(
+        <I18nProvider translations={translations} lang="sv" initialLang="en" initialized>
+          <Message
+            id={template}
+            comment="Foo"
+            component={CustomComponent}
+            className="CustomClassName"
+            foo="bar"
+          />
+        </I18nProvider>,
+      );
+
+      expect(message.text()).toEqual('före  efter');
+      expect(toJson(message)).toMatchSnapshot();
+    });
   });
 
   describe('plural', () => {
     it('translate singular form of plural messages', () => {
       const singularPTTranslation = 'Você tem uma mensagem';
-      const pluralPTTranslation = 'Você tem {count} mensagens'
+      const pluralPTTranslation = 'Você tem {count} mensagens';
       const translations = {
         pt: {
           'You have one message': singularPTTranslation,
@@ -179,7 +233,7 @@ describe('Message', () => {
 
     it('translate plural messages', () => {
       const singularPTTranslation = 'Você tem uma mensagem';
-      const pluralPTTranslation = 'Você tem {count} mensagens'
+      const pluralPTTranslation = 'Você tem {count} mensagens';
       const translations = {
         pt: {
           'You have one message': singularPTTranslation,

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -65,6 +65,92 @@ describe('Message', () => {
     });
   });
 
+  describe('with a custom component', () => {
+    it('wraps the text with the custom component', () => {
+      const translations = {
+        pt: {
+          'Hello {jsx-start}Joe{jsx-end}': 'Olá {jsx-start}Joe{jsx-end}',
+        },
+        en: {
+          'Hello {jsx-start}Joe{jsx-end}': 'Olá {jsx-start}Joe{jsx-end}',
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const message = mount(
+        <I18nProvider translations={translations} lang="pt" initialLang="en" initialized>
+          <Message
+            id="Hello {jsx-start}Joe{jsx-end}"
+            comment="Foo"
+            component={CustomComponent}
+            className="CustomClassName"
+            foo="bar"
+          />
+        </I18nProvider>,
+      );
+
+      expect(message.text()).toEqual('Olá Joe');
+      expect(toJson(message)).toMatchSnapshot();
+    });
+
+    it('it accepts a custom component and wrapped variables', () => {
+      const translations = {
+        pt: {
+          'Hello {jsx-start}{name}{jsx-end}': 'Olá {jsx-start}{name}{jsx-end}',
+        },
+        en: {
+          'Hello {jsx-start}{name}{jsx-end}': 'Olá {jsx-start}{name}{jsx-end}',
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const message = mount(
+        <I18nProvider translations={translations} lang="pt" initialLang="en" initialized>
+          <Message
+            id="Hello {jsx-start}{name}{jsx-end}"
+            values={{
+              name: 'Joe',
+            }}
+            comment="Foo"
+            component={CustomComponent}
+            className="CustomClassName"
+            foo="bar"
+          />
+        </I18nProvider>,
+      );
+
+      expect(message.text()).toEqual('Olá Joe');
+      expect(toJson(message)).toMatchSnapshot();
+    });
+
+    it('it accepts a custom component and variables', () => {
+      const translations = {
+        pt: {
+          'Hello {name} {jsx-start}Doe{jsx-end}': 'Olá {name} {jsx-start}Doe{jsx-end}',
+        },
+        en: {
+          'Hello {name} {jsx-start}Doe{jsx-end}': 'Olá {name} {jsx-start}Doe{jsx-end}',
+        },
+      };
+      const CustomComponent = ({ children }) => <div>{children}</div>;
+      const message = mount(
+        <I18nProvider translations={translations} lang="pt" initialLang="en" initialized>
+          <Message
+            id="Hello {name} {jsx-start}Doe{jsx-end}"
+            values={{
+              name: 'John',
+            }}
+            comment="Foo"
+            component={CustomComponent}
+            className="CustomClassName"
+            foo="bar"
+          />
+        </I18nProvider>,
+      );
+
+      expect(message.text()).toEqual('Olá John Doe');
+      expect(toJson(message)).toMatchSnapshot();
+    });
+  });
+
   describe('plural', () => {
     it('translate singular form of plural messages', () => {
       const singularPTTranslation = 'Você tem uma mensagem';


### PR DESCRIPTION
Add support for custom react components

Usage:
```javascript
<Message
  id="My {jsx-start}wrapped{jsx-end} text"
  comment="A custom wrapped example"
  component="div"
  className="CustomClassName"
/>
```

Will return the following:
```
My <span><div className="CustomClassName">wrapped</div></span> text
```

Important:
- Only one occurrence of `{jsx-start}{jsx-end}` per message
- Throws if only having one of `{jsx-start}` and `{jsx-end}`
- Throws if having `{jsx-start}{jsx-end}` without custom component
- Renders the custom component without children if having `{jsx-start}{jsx-end}`
- It can wrap or normally live together with other variables, like:
-- `{jsx-start}{var}{jsx-end}`
-- `{var} {jsx-start}foo{jsx-end} {var2}`